### PR TITLE
Thesaurus command no longer throws a NullReferenceException if there isn't an example

### DIFF
--- a/Commands/DictionaryCommands.cs
+++ b/Commands/DictionaryCommands.cs
@@ -1,6 +1,5 @@
 using Discord.Commands;
 
-using System;
 using System.Net;
 using System.IO;
 using System.Linq;
@@ -118,7 +117,10 @@ namespace BotMyst.Commands
                     int nOfSenses = 1;
                     foreach (ThesaurusSense sense in entry.Senses ?? Enumerable.Empty<ThesaurusSense> ())
                     {
-                        finalMessage += $"{nOfSenses}. \"{sense.Examples [0].Text.UppercaseFirst ()}.\"\n";
+                        if (sense.Examples != null)
+                            finalMessage += $"{nOfSenses}. \"{sense.Examples [0].Text.UppercaseFirst ()}.\"\n";
+                        else
+                            finalMessage += $"{nOfSenses}.\n";
 
                         if (sense.Synonyms != null || sense.Synonyms.Length >= 1)
                         {


### PR DESCRIPTION
### Fixed:
Thesaurus would throw a NullReferenceException on the word "witch" because it didn't have an example for one of the senses.

It won't do that again. But if there isn't an example the message will look something like this:
>**WITCH**
>
>1 *<here goes the example, but since there isn't one it's empty.>*
>**Synonyms**
>Sorceress, enchantress, occultist, necromancer, Wiccan.
